### PR TITLE
Basic support for rebooting into the bootloader.

### DIFF
--- a/firmware/tools/README.md
+++ b/firmware/tools/README.md
@@ -17,7 +17,21 @@ Run `filter_test` to process the PCM samples. The `filter_test` program takes tw
 You can listen to the PCM files using ffplay (which is usually included with ffmpeg):
 
 ```
-./ffplay -f s16le -ar 48000 -ac 2 output.pcm
+ffplay -f s16le -ar 48000 -ac 2 output.pcm
 ```
 
 If there are no obvious problems, go ahead and flash your firmware.
+
+## reboot_bootloader.py
+If your Ploopy Headphones firmware is new enough, it has support for a USB vendor command that will cause the RP2040 to reboot into the
+bootloader. This will enable you to update the firmware without having to remove the case and short the pins on the board.
+
+### Usage
+Connect the Ploopy headphones DAC and run:
+
+```
+./reboot_bootloader.py
+```
+
+You will need python3 and the pyusb module. If you get a permission denied error you may need to configure your udev rules, or run the
+script with administrator privileges.

--- a/firmware/tools/reboot_bootloader.py
+++ b/firmware/tools/reboot_bootloader.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+import usb.core
+from usb.util import *
+
+REBOOT_BOOTLOADER = 0
+PLOOPY_VID = 0x2e8a
+PLOOPY_PID = 0xfedd
+
+device_count = 0
+
+# Find all connected Ploopy headphone devices
+for dev in usb.core.find(find_all=True, idVendor=PLOOPY_VID, idProduct=PLOOPY_PID):
+    device_count += 1
+
+    # The vendor command expects the wValue to be equal to the Ploopy vendor id. This
+    # will hopefully prevent badly behaved software from accidentally triggering bootloader
+    # mode.
+    try:
+        dev.ctrl_transfer(CTRL_RECIPIENT_DEVICE | CTRL_TYPE_VENDOR, REBOOT_BOOTLOADER, PLOOPY_VID)
+    except Exception as e:
+        # The headphones do not respond to the vendor command, as they have already rebooted,
+        # so for now, we always end up here.
+        if e.errno == 32:
+            # libusb pipe error, this is expected. OpenUSB doesnt report an error.
+            pass
+        else:
+            print(e)
+
+print(f"Sent a reboot command to {device_count} Ploopy devices.")


### PR DESCRIPTION
This PR adds a USB vendor command that causes the RP2040 to reboot into the bootloader. This enables you to flash new firmware without having to open up the case and short pins on the board.

There is also a simple python script which issues the vendor command to all connected Ploopy DAC devices.

Tested on Linux using a Raspberry Pi Pico.