### PR TITLE
PCM3060 volume control

### DIFF
--- a/firmware/code/run.h
+++ b/firmware/code/run.h
@@ -125,7 +125,7 @@ static bool do_get_minimum(struct usb_setup_packet *);
 static bool do_get_maximum(struct usb_setup_packet *);
 static bool do_get_resolution(struct usb_setup_packet *);
 static void _audio_reconfigure(void);
-static void audio_set_volume(int16_t);
+static void audio_set_volume(int8_t, int16_t);
 static void audio_cmd_packet(struct usb_endpoint *);
 static bool as_set_alternate(struct usb_interface *, uint);
 static bool do_set_current(struct usb_setup_packet *);

--- a/firmware/code/run.h
+++ b/firmware/code/run.h
@@ -40,10 +40,10 @@
 
 #define ENCODE_DB(x) ((uint16_t)(int16_t)((x)*256))
 
-#define MIN_VOLUME ENCODE_DB(-CENTER_VOLUME_INDEX)
+#define MIN_VOLUME ENCODE_DB(-100)
 #define DEFAULT_VOLUME ENCODE_DB(0)
-#define MAX_VOLUME ENCODE_DB(count_of(db_to_vol)-CENTER_VOLUME_INDEX)
-#define VOLUME_RESOLUTION ENCODE_DB(1)
+#define MAX_VOLUME ENCODE_DB(0)
+#define VOLUME_RESOLUTION ENCODE_DB(0.5f)
 
 typedef struct _audio_device_config {
     struct usb_configuration_descriptor descriptor;

--- a/firmware/code/user.c
+++ b/firmware/code/user.c
@@ -19,47 +19,46 @@
 #include "bqf.h"
 #include "run.h"
 
+int FILTER_STAGES = 0;
+
 /*****************************************************************************
  * Here is where your digital signal processing journey begins. Follow this
  * guide, and don't forget any steps!
  *
- * 1. Go to user.h and change FILTER_STAGES to the number of filter stages you
- * want.
- * 2. Define the filters that you want to use. Check out "bqf.c" for a
+ * 1. Define the filters that you want to use. Check out "bqf.c" for a
  * complete list of what they are and how they work. Using those filters, you
  * can create ANY digital signal shape you want. Anything you can dream of.
- * 3. You're done! Enjoy the sounds of anything you want.
+ * 2. You're done! Enjoy the sounds of anything you want.
  ****************************************************************************/
 
 void define_filters() {
-
     // First filter.
-    bqf_memreset(&bqf_filters_mem_left[0]);
-    bqf_memreset(&bqf_filters_mem_right[0]);
-    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_left[0]);
-    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_right[0]);
+    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
+    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
+    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_left[FILTER_STAGES]);
+    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_right[FILTER_STAGES++]);
     
     // Second filter.
-    bqf_memreset(&bqf_filters_mem_left[1]);
-    bqf_memreset(&bqf_filters_mem_right[1]);
-    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_left[1]);
-    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_right[1]);
+    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
+    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
+    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_left[FILTER_STAGES]);
+    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_right[FILTER_STAGES++]);
 
     // Third filter.
-    bqf_memreset(&bqf_filters_mem_left[2]);
-    bqf_memreset(&bqf_filters_mem_right[2]);
-    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_left[2]);
-    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_right[2]);
-    
+    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
+    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
+    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_left[FILTER_STAGES]);
+    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_right[FILTER_STAGES++]);
+
     // Fourth filter.
-    bqf_memreset(&bqf_filters_mem_left[3]);
-    bqf_memreset(&bqf_filters_mem_right[3]);
-    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_left[3]);
-    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_right[3]);
+    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
+    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
+    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_left[FILTER_STAGES]);
+    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_right[FILTER_STAGES++]);
 
     // Fifth filter.
-    bqf_memreset(&bqf_filters_mem_left[4]);
-    bqf_memreset(&bqf_filters_mem_right[4]);
-    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_left[4]);
-    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_right[4]);
+    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
+    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
+    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_left[FILTER_STAGES]);
+    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_right[FILTER_STAGES++]);
 }

--- a/firmware/code/user.c
+++ b/firmware/code/user.c
@@ -19,7 +19,7 @@
 #include "bqf.h"
 #include "run.h"
 
-int FILTER_STAGES = 0;
+int filter_stages = 0;
 
 /*****************************************************************************
  * Here is where your digital signal processing journey begins. Follow this
@@ -33,32 +33,32 @@ int FILTER_STAGES = 0;
 
 void define_filters() {
     // First filter.
-    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
-    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
-    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_left[FILTER_STAGES]);
-    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_right[FILTER_STAGES++]);
+    bqf_memreset(&bqf_filters_mem_left[filter_stages]);
+    bqf_memreset(&bqf_filters_mem_right[filter_stages]);
+    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_left[filter_stages]);
+    bqf_peaking_config(SAMPLING_FREQ, 38.0, -19.0, 0.9, &bqf_filters_right[filter_stages++]);
     
     // Second filter.
-    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
-    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
-    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_left[FILTER_STAGES]);
-    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_right[FILTER_STAGES++]);
+    bqf_memreset(&bqf_filters_mem_left[filter_stages]);
+    bqf_memreset(&bqf_filters_mem_right[filter_stages]);
+    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_left[filter_stages]);
+    bqf_lowshelf_config(SAMPLING_FREQ, 2900.0, 3.0, 4.0, &bqf_filters_right[filter_stages++]);
 
     // Third filter.
-    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
-    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
-    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_left[FILTER_STAGES]);
-    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_right[FILTER_STAGES++]);
+    bqf_memreset(&bqf_filters_mem_left[filter_stages]);
+    bqf_memreset(&bqf_filters_mem_right[filter_stages]);
+    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_left[filter_stages]);
+    bqf_peaking_config(SAMPLING_FREQ, 430.0, 6.0, 3.5, &bqf_filters_right[filter_stages++]);
 
     // Fourth filter.
-    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
-    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
-    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_left[FILTER_STAGES]);
-    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_right[FILTER_STAGES++]);
+    bqf_memreset(&bqf_filters_mem_left[filter_stages]);
+    bqf_memreset(&bqf_filters_mem_right[filter_stages]);
+    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_left[filter_stages]);
+    bqf_highshelf_config(SAMPLING_FREQ, 8400.0, 3.0, 4.0, &bqf_filters_right[filter_stages++]);
 
     // Fifth filter.
-    bqf_memreset(&bqf_filters_mem_left[FILTER_STAGES]);
-    bqf_memreset(&bqf_filters_mem_right[FILTER_STAGES]);
-    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_left[FILTER_STAGES]);
-    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_right[FILTER_STAGES++]);
+    bqf_memreset(&bqf_filters_mem_left[filter_stages]);
+    bqf_memreset(&bqf_filters_mem_right[filter_stages]);
+    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_left[filter_stages]);
+    bqf_peaking_config(SAMPLING_FREQ, 4800.0, 6.0, 5.0, &bqf_filters_right[filter_stages++]);
 }

--- a/firmware/code/user.h
+++ b/firmware/code/user.h
@@ -20,8 +20,10 @@
 
 #include "bqf.h"
 
+// In reality we do not have enough CPU resource to run 8 filtering
+// stages without some optimisation.
 #define MAX_FILTER_STAGES 8
-extern int FILTER_STAGES;
+extern int filter_stages;
 
 extern bqf_coeff_t bqf_filters_left[MAX_FILTER_STAGES];
 extern bqf_coeff_t bqf_filters_right[MAX_FILTER_STAGES];

--- a/firmware/code/user.h
+++ b/firmware/code/user.h
@@ -20,13 +20,13 @@
 
 #include "bqf.h"
 
-// todo fix this. people will forget this.
-#define FILTER_STAGES 5  // Don't forget to set this to the right size!
+#define MAX_FILTER_STAGES 8
+extern int FILTER_STAGES;
 
-extern bqf_coeff_t bqf_filters_left[FILTER_STAGES];
-extern bqf_coeff_t bqf_filters_right[FILTER_STAGES];
-extern bqf_mem_t bqf_filters_mem_left[FILTER_STAGES];
-extern bqf_mem_t bqf_filters_mem_right[FILTER_STAGES];
+extern bqf_coeff_t bqf_filters_left[MAX_FILTER_STAGES];
+extern bqf_coeff_t bqf_filters_right[MAX_FILTER_STAGES];
+extern bqf_mem_t bqf_filters_mem_left[MAX_FILTER_STAGES];
+extern bqf_mem_t bqf_filters_mem_right[MAX_FILTER_STAGES];
 
 void define_filters(void);
 

--- a/firmware/tools/README.md
+++ b/firmware/tools/README.md
@@ -5,7 +5,7 @@ This is a basic utility for testing the Ploopy headphones filtering routines on 
 Find a source file and use ffmpeg to convert it to 16bit stereo PCM samples:
 
 ```
-ffmpeg -i <input file> -map 0:6 -vn -f s16le -acodec pcm_s16le input.pcm
+ffmpeg -i <input file> -vn -f s16le -acodec pcm_s16le input.pcm
 ```
 
 Run `filter_test` to process the PCM samples. The `filter_test` program takes two arguments an input file and an output file:

--- a/firmware/tools/filter_test.c
+++ b/firmware/tools/filter_test.c
@@ -4,10 +4,10 @@
 #include "fix16.h"
 #include "user.h"
 
-bqf_coeff_t bqf_filters_left[FILTER_STAGES];
-bqf_coeff_t bqf_filters_right[FILTER_STAGES];
-bqf_mem_t bqf_filters_mem_left[FILTER_STAGES];
-bqf_mem_t bqf_filters_mem_right[FILTER_STAGES];
+bqf_coeff_t bqf_filters_left[MAX_FILTER_STAGES];
+bqf_coeff_t bqf_filters_right[MAX_FILTER_STAGES];
+bqf_mem_t bqf_filters_mem_left[MAX_FILTER_STAGES];
+bqf_mem_t bqf_filters_mem_right[MAX_FILTER_STAGES];
 
 const char* usage = "Usage: %s INFILE OUTFILE\n\n"
     "Reads 16bit stereo PCM data from INFILE, runs it through the Ploopy headphones\n"

--- a/firmware/tools/filter_test.c
+++ b/firmware/tools/filter_test.c
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
         out[i] = in[i];
     }
 
-    for (int j = 0; j < FILTER_STAGES; j++)
+    for (int j = 0; j < filter_stages; j++)
     {
         for (int i = 0; i < samples; i ++)
         {


### PR DESCRIPTION
This PR offloads the volume control to the PCM3060 code. This has a few minor advantages to the current approach:
- It saves a few cycles on the RP2040.
- The PCM3060 provides a gradual ramp when the volume changes.

Also included are:
- Independent left/right volume control. In Windows you might need to delete the headphone device in the device manager to get it to re-parse the descriptors and show the UI:  ![image](https://github.com/ploopyco/headphones/assets/30636555/d8fb0b14-c02c-4632-871a-499b01331b76)
- Tweaked the filter index management so it is a bit more automatic.
