### PR TITLE
Fix the LRCK signal which was reversing the channels.

### DIFF
--- a/firmware/code/i2s.pio
+++ b/firmware/code/i2s.pio
@@ -20,15 +20,15 @@
 set x, 30                   side 0b00
 
 left_channel:
-    in pins, 1              side 0b01
-    jmp x-- left_channel    side 0b00
+    in pins, 1              side 0b11
+    jmp x-- left_channel    side 0b10
     in pins, 1              side 0b11
 
 set x, 30                   side 0b10
 
 right_channel:
-    in pins, 1              side 0b11
-    jmp x--, right_channel  side 0b10
+    in pins, 1              side 0b01
+    jmp x--, right_channel  side 0b00
     in pins, 1              side 0b01
 
 
@@ -38,13 +38,13 @@ right_channel:
 set x, 30                   side 0b01
 
 left_channel:
-    out pins, 1             side 0b00
-    jmp x-- left_channel    side 0b01
+    out pins, 1             side 0b10
+    jmp x-- left_channel    side 0b11
     out pins, 1             side 0b10
 
 set x, 30                   side 0b11
 
 right_channel:
-    out pins, 1             side 0b10
-    jmp x--, right_channel  side 0b11
+    out pins, 1             side 0b00
+    jmp x--, right_channel  side 0b01
     out pins, 1             side 0b00


### PR DESCRIPTION
Fix the LRCK signal which caused reversed channels after my previous PR.

For reference, the clocking for the old data format is here:
![image](https://github.com/ploopyco/headphones/assets/30636555/bcdae50a-6c30-4893-8efd-6f9db3e4d830)
And the new data format is here:
![image](https://github.com/ploopyco/headphones/assets/30636555/6add4fd1-3cd9-4552-94d3-952011e3ce52)

The old volume code had a side effect of shifting the 16bit values to the top end of the 32bit word which is written to I2S. I was a bit surprised to see the maximum volume of 0x7FFF, which shifts the data into bits 30-15 rather than 31-16. I assumed this generated the BCK pulse before the first bit is written, but now I see that is not the case. I suspect this was just an error. As a result this fix adds a small, but useful increase in the max volume.