### PR TITLE
Oratory1990 EQ profile

### DIFF
--- a/firmware/code/configuration_manager.c
+++ b/firmware/code/configuration_manager.c
@@ -52,13 +52,16 @@ static const default_configuration default_config = {
     .set_configuration = { SET_CONFIGURATION, sizeof(default_config) },
     .filters = {
         .filter = { FILTER_CONFIGURATION, sizeof(default_config.filters) },
-        .f1 = { PEAKING,    {0},    38,   -19,  0.9 },
-        .f2 = { LOWSHELF,   {0},    2900,   2,  0.7 },
-        .f3 = { PEAKING,    {0},    430,    3,  3.5 },
-        .f4 = { HIGHSHELF,  {0},    8400,   2,  0.7 },
-        .f5 = { PEAKING,    {0},    4800,   3,    5 }
+        .f1 = { PEAKING,    {0},    40,   -20,  1.4 },
+        .f2 = { LOWSHELF,   {0},    105,  2.5,  0.7 },
+        .f3 = { PEAKING,    {0},    450,  7,    1.8 },
+        .f4 = { PEAKING,    {0},    2100, 8,    3.0 },
+        .f5 = { PEAKING,    {0},    3500, -7.5, 2.9 },
+        .f6 = { PEAKING,    {0},    5200, 5.5,  3.0 },
+        .f7 = { PEAKING,    {0},    6400, -19,  4.0 },
+        .f8 = { PEAKING,    {0},    9000, 3.0,  2.0 }
     },
-    .preprocessing = { .header = { PREPROCESSING_CONFIGURATION, sizeof(default_config.preprocessing) }, -0.2f, false, {0} }
+    .preprocessing = { .header = { PREPROCESSING_CONFIGURATION, sizeof(default_config.preprocessing) }, -0.16f, true, {0} }
 };
 
 // Grab the last 4k page of flash for our configuration strutures.

--- a/firmware/code/configuration_types.h
+++ b/firmware/code/configuration_types.h
@@ -134,6 +134,9 @@ typedef struct __attribute__((__packed__)) _default_configuration {
         filter3 f3;
         filter3 f4;
         filter3 f5;
+        filter3 f6;
+        filter3 f7;
+        filter3 f8;
     } filters;
     preprocessing_configuration_tlv preprocessing;
 } default_configuration;


### PR DESCRIPTION
- Replaced default EQ filter set with an 8-band EQ based on measurements from Oratory1990 and VSG
- Default configuration reverses the left/right channels in the DAC, because the headphones are wired backwards (oopie!)