### PR TITLE
Fix off by one error in fix_28_t

### DIFF
--- a/firmware/code/fix16.inl
+++ b/firmware/code/fix16.inl
@@ -32,11 +32,12 @@ static inline fix3_28_t norm_fix3_28_from_s16sample(int16_t a) {
     /* So, we're using a Q3.28 fixed point system here, and we want the incoming
        audio signal to be represented as a number between -1 and 1. To do this,
        we need the 16-bit value to map to the 28-bit right-of-decimal field in
-       our fixed point number. 28-16 = 12, so we shift the incoming value by
+       our fixed point number. The 16 bit samples are siged, so bit 15 needs to
+       be positioned at bit 28. 28-15 = 13, so we shift the incoming value by
        that much to covert it to the desired Q3.28 format and do the normalization
        all in one go.
     */
-    return (fix3_28_t)a << 12;
+    return (fix3_28_t)a << 13;
 }
 
 /// @brief Convert fixed point samples into signed integer. Used to convert
@@ -69,9 +70,9 @@ static inline int16_t norm_fix3_28_to_s16sample(fix3_28_t a) {
         }
     }
     /* When we converted the USB audio sample to a fixed point number, we applied
-       a normalization, or a gain of 1/65536. To convert it back, we can undo that
+       a normalization, or a gain of 1/32767. To convert it back, we can undo that
        by shifting it back by the same amount we shifted it in the first place. */
-    return (a >> 12);
+    return (a >> 13);
 }
 
 static inline fix3_28_t fix3_28_from_flt(float a) {

--- a/firmware/code/run.c
+++ b/firmware/code/run.c
@@ -194,7 +194,7 @@ void __no_inline_not_in_flash_func(core1_entry)() {
                 x_f16 = bqf_transform(x_f16, &bqf_filters_right[j],
                     &bqf_filters_mem_right[j]);
 
-                out[i] = (int16_t) norm_fix3_28_to_s16sample(x_f16);
+                out[i] = (int32_t) norm_fix3_28_to_s16sample(x_f16);
             }
         }
 


### PR DESCRIPTION
I believe there is an out by one error in the sample normalization code, it doesn't account for the sign bit in the sample.

The min sample value is `0x8000` (`-32768`) and the max value is `0x7FFF` (`32767`), these should map to fixed point values `0xF0000000` (`-1`) and `0x0FFFE000` (`0.999969482`)  but currently they end up as `0xF8000000` (`−0.5`) and  `0x7FFF000` (`0.499984741`). In practice this doesn't have much of an effect as when converting back to a sample we also take the wrong bits, but numbers which originated as floats/doubles are twice as big as expected relative to the samples. I suspect there is no major effect with the filter coefficients, but the preamp scaling is probably a bit off.