### PR TITLE
Fix save config

### DIFF
--- a/firmware/code/configuration_manager.c
+++ b/firmware/code/configuration_manager.c
@@ -404,6 +404,7 @@ bool __no_inline_not_in_flash_func(save_config)() {
             saveState = NormalOperation;
             return false;
         default:
+            break;
     }
 
     return false;

--- a/firmware/code/configuration_manager.c
+++ b/firmware/code/configuration_manager.c
@@ -433,6 +433,12 @@ bool process_cmd(tlv_header* cmd) {
         case SAVE_CONFIGURATION: {
             if (cmd->length == 4) {
                 saveState = SaveRequested;
+                if (audio_state.interface == 0) {
+                    // The OS will configure the alternate "zero" interface when the device is not in use
+                    // in this sate we can write to flash now. Otherwise, defer the save until we get the next
+                    // usb packet.
+                    save_config();
+                }
                 result->type = OK;
                 result->length = 4;
                 return true;

--- a/firmware/code/configuration_manager.c
+++ b/firmware/code/configuration_manager.c
@@ -96,6 +96,13 @@ static bool reload_config = false;
 static uint16_t write_offset = 0;
 static uint16_t read_offset = 0;
 
+typedef enum {
+    NormalOperation,
+    SaveRequested,
+    Saving
+} State;
+static State saveState = NormalOperation;
+
 bool validate_filter_configuration(filter_configuration_tlv *filters)
 {
     if (filters->header.type != FILTER_CONFIGURATION) {
@@ -357,37 +364,46 @@ void load_config() {
 }
 
 #ifndef TEST_TARGET
-bool __no_inline_not_in_flash_func(save_configuration)() {
-
-
-    
+bool __no_inline_not_in_flash_func(save_config)() {
     const uint8_t active_configuration = inactive_working_configuration ? 0 : 1;
     tlv_header* config = (tlv_header*) working_configuration[active_configuration];
 
-    if (validate_configuration(config)) {      
+    switch (saveState) {
+        case SaveRequested:
+            if (validate_configuration(config)) {      
+                /* Turn the DAC off so we don't make a huge noise when disrupting
+                real time audio operation. */
+                power_down_dac();
 
-        const size_t config_length = config->length - ((size_t)config->value - (size_t)config);
-        // Write data to flash
-        uint8_t flash_buffer[CFG_BUFFER_SIZE];
-        flash_header_tlv* flash_header = (flash_header_tlv*) flash_buffer;
-        flash_header->header.type = FLASH_HEADER;
-        flash_header->header.length = sizeof(flash_header_tlv) + config_length;
-        flash_header->magic = FLASH_MAGIC;
-        flash_header->version = CONFIG_VERSION;
-        memcpy((void*)(flash_header->tlvs), config->value, config_length);
+                const size_t config_length = config->length - ((size_t)config->value - (size_t)config);
+                // Write data to flash
+                uint8_t flash_buffer[CFG_BUFFER_SIZE];
+                flash_header_tlv* flash_header = (flash_header_tlv*) flash_buffer;
+                flash_header->header.type = FLASH_HEADER;
+                flash_header->header.length = sizeof(flash_header_tlv) + config_length;
+                flash_header->magic = FLASH_MAGIC;
+                flash_header->version = CONFIG_VERSION;
+                memcpy((void*)(flash_header->tlvs), config->value, config_length);
 
-        /* Turn the DAC off so we don't make a huge noise when disrupting
-           real time audio operation. */
-        power_down_dac();
+                uint32_t ints = save_and_disable_interrupts();
+                flash_range_erase(USER_CONFIGURATION_OFFSET, FLASH_SECTOR_SIZE);
+                flash_range_program(USER_CONFIGURATION_OFFSET, flash_buffer, CFG_BUFFER_SIZE);
+                restore_interrupts(ints);
+                saveState = Saving;
 
-        uint32_t ints = save_and_disable_interrupts();
-        flash_range_erase(USER_CONFIGURATION_OFFSET, FLASH_SECTOR_SIZE);
-        flash_range_program(USER_CONFIGURATION_OFFSET, flash_buffer, CFG_BUFFER_SIZE);
-        restore_interrupts(ints);
-
-        power_up_dac();
-
-        return true;
+                // Return true, so the caller skips processing audio
+                return true;
+            }
+            // Validation failed, give up.
+            saveState = NormalOperation;
+            break;
+        case Saving:
+            /* Turn the DAC off so we don't make a huge noise when disrupting
+            real time audio operation. */
+            power_up_dac();
+            saveState = NormalOperation;
+            return false;
+        default:
     }
 
     return false;
@@ -415,7 +431,8 @@ bool process_cmd(tlv_header* cmd) {
             }
             break;
         case SAVE_CONFIGURATION: {
-            if (cmd->length == 4 && save_configuration()) {
+            if (cmd->length == 4) {
+                saveState = SaveRequested;
                 result->type = OK;
                 result->length = 4;
                 return true;

--- a/firmware/code/configuration_manager.h
+++ b/firmware/code/configuration_manager.h
@@ -52,6 +52,7 @@ void config_in_packet(struct usb_endpoint *ep);
 void config_out_packet(struct usb_endpoint *ep);
 void configuration_ep_on_cancel(struct usb_endpoint *ep);
 extern void load_config();
+extern bool save_config();
 extern void apply_config_changes();
 
 #endif // CONFIGURATION_MANAGER_H

--- a/firmware/code/run.c
+++ b/firmware/code/run.c
@@ -52,6 +52,7 @@ static uint8_t *userbuf;
 audio_state_config audio_state = {
     .freq = 48000,
     .de_emphasis_frequency = 0x1, // 48khz
+    .interface = 0
 };
 
 preprocessing_config preprocessing = {
@@ -769,6 +770,7 @@ static const struct usb_transfer_type _audio_cmd_transfer_type = {
 
 static bool as_set_alternate(struct usb_interface *interface, uint alt) {
     assert(interface == &as_op_interface);
+    audio_state.interface = alt;
     switch (alt) {
         case 0: power_down_dac(); return true;
         case 1: power_up_dac(); return true;

--- a/firmware/code/run.h
+++ b/firmware/code/run.h
@@ -149,6 +149,7 @@ static char *descriptor_strings[] = {
 #define SAMPLING_FREQ (CODEC_FREQ / 192)
 
 #define CORE0_READY 19813219
+#define CORE0_ABORTED 91231891
 #define CORE1_READY 72965426
 
 /*****************************************************************************

--- a/firmware/code/run.h
+++ b/firmware/code/run.h
@@ -76,6 +76,7 @@ typedef struct _audio_state_config {
         int16_t _target_pcm3060_registers;
     };
     int16_t pcm3060_registers;
+    int8_t interface;
 } audio_state_config;
 extern audio_state_config audio_state;
 


### PR DESCRIPTION
This PR moves the save config functionality to the top of the audio processing callback, we skip processing the audio packet if we need to save. This frees up a load of cycles for writing to flash. If no audio is playing we save immediately as we might not get a callback at all.